### PR TITLE
fix(indexer): paginate historical backfill per relay with resumable checkpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: lighthouse
     restart: unless-stopped
     ports:
-      - "9999:9999"
+      - "${PORT:-9999}:9999"
     volumes:
       - lighthouse_data:/app/data
       - lighthouse_config:/app/config

--- a/internal/database/schema.sql
+++ b/internal/database/schema.sql
@@ -290,6 +290,22 @@ CREATE TABLE IF NOT EXISTS relay_events (
 );
 
 -- =====================================================
+-- RELAY BACKFILL PROGRESS
+-- =====================================================
+
+-- Per-relay historical backfill checkpoint. Lets the resync walker resume
+-- backwards pagination across container restarts instead of starting over.
+-- oldest_fetched_at is the unix timestamp of the oldest event we've pulled
+-- from this relay so far; the next backfill page starts with Until = that.
+CREATE TABLE IF NOT EXISTS relay_backfill_progress (
+    relay_url           TEXT PRIMARY KEY,
+    oldest_fetched_at   INTEGER NOT NULL DEFAULT 0,
+    newest_fetched_at   INTEGER NOT NULL DEFAULT 0,
+    completed           INTEGER NOT NULL DEFAULT 0,
+    last_updated_at     DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- =====================================================
 -- ACTIVITY LOG
 -- =====================================================
 

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -329,6 +329,62 @@ func GetLatestEventTimestamp() (int64, error) {
 	return ts, err
 }
 
+// RelayBackfillProgress tracks how far backwards we've paginated history
+// for a single relay, so that resync can resume across restarts.
+type RelayBackfillProgress struct {
+	RelayURL        string
+	OldestFetchedAt int64
+	NewestFetchedAt int64
+	Completed       bool
+}
+
+// GetRelayBackfillProgress returns the checkpoint row for a relay. If no row
+// exists yet, it returns a zero-value struct (OldestFetchedAt == 0) and nil
+// error — callers should treat that as "start from now".
+func GetRelayBackfillProgress(relayURL string) (RelayBackfillProgress, error) {
+	var p RelayBackfillProgress
+	p.RelayURL = relayURL
+	var completed int
+	err := db.QueryRow(`
+		SELECT oldest_fetched_at, newest_fetched_at, completed
+		FROM relay_backfill_progress
+		WHERE relay_url = ?
+	`, relayURL).Scan(&p.OldestFetchedAt, &p.NewestFetchedAt, &completed)
+	if err == sql.ErrNoRows {
+		return p, nil
+	}
+	if err != nil {
+		return p, err
+	}
+	p.Completed = completed != 0
+	return p, nil
+}
+
+// UpdateRelayBackfillProgress upserts the checkpoint for a relay. The newest
+// and oldest watermarks are merged with any existing row so a resync that
+// only walks backwards doesn't clobber the newest watermark recorded earlier.
+func UpdateRelayBackfillProgress(relayURL string, oldest, newest int64, completed bool) error {
+	completedInt := 0
+	if completed {
+		completedInt = 1
+	}
+	_, err := db.Exec(`
+		INSERT INTO relay_backfill_progress
+			(relay_url, oldest_fetched_at, newest_fetched_at, completed, last_updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(relay_url) DO UPDATE SET
+			oldest_fetched_at = CASE
+				WHEN relay_backfill_progress.oldest_fetched_at = 0 THEN excluded.oldest_fetched_at
+				WHEN excluded.oldest_fetched_at = 0 THEN relay_backfill_progress.oldest_fetched_at
+				ELSE MIN(relay_backfill_progress.oldest_fetched_at, excluded.oldest_fetched_at)
+			END,
+			newest_fetched_at = MAX(relay_backfill_progress.newest_fetched_at, excluded.newest_fetched_at),
+			completed = excluded.completed,
+			last_updated_at = CURRENT_TIMESTAMP
+	`, relayURL, oldest, newest, completedInt)
+	return err
+}
+
 // LogActivity logs an activity event
 func LogActivity(eventType string, details string) error {
 	_, err := db.Exec(`

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -421,7 +421,15 @@ func (idx *Indexer) enrichPendingTorrents() {
 	}
 }
 
-// FetchHistorical fetches historical torrents from relays
+// FetchHistorical fetches historical torrents from relays by walking each
+// connected relay backwards with bounded pagination. Per-relay checkpoints in
+// the relay_backfill_progress table let this resume across restarts.
+//
+// days == 0 means "no time limit" (walk until each relay reports an empty
+// page). days > 0 stops the walk when it crosses the (now - days) floor.
+//
+// If no relays are currently connected, falls back to the legacy single-REQ
+// SubscribeTrustedTorrents path so the caller still gets *something*.
 func (idx *Indexer) FetchHistorical(days int) error {
 	if !idx.IsRunning() {
 		return nil
@@ -449,16 +457,48 @@ func (idx *Indexer) FetchHistorical(days int) error {
 		trustedPubkeys = append(trustedPubkeys, pubkey)
 	}
 
-	if days == 0 {
-		log.Info().Int("uploaders", len(trustedPubkeys)).Msg("Fetching all historical torrents from trusted uploaders")
-	} else {
-		log.Info().Int("days", days).Int("uploaders", len(trustedPubkeys)).Msg("Fetching historical torrents from trusted uploaders")
+	var sinceFloor int64
+	if days > 0 {
+		sinceFloor = time.Now().Add(-time.Duration(days) * 24 * time.Hour).Unix()
 	}
 
-	// Re-subscribe to get fresh data from trusted uploaders
-	return idx.relayManager.SubscribeTrustedTorrents(idx.ctx, trustedPubkeys, func(event *gonostr.Event, relayURL string) {
-		idx.processEvent(event, relayURL)
-	})
+	if days == 0 {
+		log.Info().Int("uploaders", len(trustedPubkeys)).Msg("Backfilling all historical torrents from trusted uploaders")
+	} else {
+		log.Info().Int("days", days).Int64("since_floor", sinceFloor).Int("uploaders", len(trustedPubkeys)).Msg("Backfilling historical torrents from trusted uploaders")
+	}
+
+	clients := idx.relayManager.GetConnectedClients()
+	if len(clients) == 0 {
+		log.Warn().Msg("No connected relays for backfill, falling back to live subscribe")
+		return idx.relayManager.SubscribeTrustedTorrents(idx.ctx, trustedPubkeys, func(event *gonostr.Event, relayURL string) {
+			idx.processEvent(event, relayURL)
+		})
+	}
+
+	// Bounded per-relay parallelism. 4 concurrent relay walkers is enough to
+	// hide latency without hammering each relay.
+	const maxParallel = 4
+	sem := make(chan struct{}, maxParallel)
+	var wg sync.WaitGroup
+
+	for _, c := range clients {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(client *nostr.Client) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if _, err := idx.relayManager.BackfillRelay(idx.ctx, client, trustedPubkeys, sinceFloor, func(event *gonostr.Event, relayURL string) {
+				idx.processEvent(event, relayURL)
+			}); err != nil {
+				log.Error().Err(err).Str("relay", client.URL()).Msg("Backfill failed for relay")
+			}
+		}(c)
+	}
+	wg.Wait()
+
+	log.Info().Int("relays", len(clients)).Msg("Backfill walk complete across all relays")
+	return nil
 }
 
 // ImportContactList imports follows from a contact list

--- a/internal/nostr/relay.go
+++ b/internal/nostr/relay.go
@@ -313,6 +313,177 @@ func (rm *RelayManager) FetchAllHistoricalTorrents(ctx context.Context, pubkeys 
 	return nil
 }
 
+// BackfillRelay performs bounded backwards pagination for kind 2003 events from
+// a single relay, resuming from a per-relay checkpoint if one exists. It is the
+// resync-friendly cousin of FetchAllHistoricalTorrents: pages backwards using
+// the Until cursor, persists progress per page so a container restart can pick
+// up where it left off, and stops when the relay reports an empty page (marks
+// completed=true) or when Until crosses the configured floor.
+//
+// sinceFloor is the unix timestamp lower bound (events older than this are not
+// fetched). Pass 0 for "no limit".
+//
+// Returns the number of events fetched from this relay.
+func (rm *RelayManager) BackfillRelay(ctx context.Context, client *Client, pubkeys []string, sinceFloor int64, handler func(*nostr.Event, string)) (int, error) {
+	if len(pubkeys) == 0 {
+		return 0, errors.New("no pubkeys provided")
+	}
+	if client == nil {
+		return 0, errors.New("nil relay client")
+	}
+
+	// Page size chosen to be friendly to relays that cap REQ responses low
+	// (e.g. U2P relays cap at 100/sub). 200 is a small over-fetch on those
+	// and a fine page size on permissive relays.
+	const pageSize = 200
+
+	url := client.URL()
+
+	// Resume from checkpoint if present.
+	progress, err := database.GetRelayBackfillProgress(url)
+	if err != nil {
+		log.Warn().Err(err).Str("relay", url).Msg("Failed to load backfill checkpoint, starting fresh")
+		progress = database.RelayBackfillProgress{RelayURL: url}
+	}
+
+	// Decide where to start the backwards walk.
+	// - If we have a previous oldest watermark, resume from just before it.
+	// - Otherwise, start from now.
+	now := time.Now().Unix()
+	startUntil := now
+	if progress.OldestFetchedAt > 0 {
+		startUntil = progress.OldestFetchedAt
+	}
+
+	var since *nostr.Timestamp
+	if sinceFloor > 0 {
+		s := nostr.Timestamp(sinceFloor)
+		since = &s
+	}
+
+	untilTs := nostr.Timestamp(startUntil)
+	until := &untilTs
+
+	// Track watermarks to persist back to the checkpoint table.
+	oldestSeen := progress.OldestFetchedAt
+	newestSeen := progress.NewestFetchedAt
+
+	totalFetched := 0
+	page := 0
+
+	log.Info().
+		Str("relay", url).
+		Int64("start_until", startUntil).
+		Int64("since_floor", sinceFloor).
+		Bool("resumed", progress.OldestFetchedAt > 0).
+		Msg("Starting backfill walk")
+
+	for {
+		// Honor cancellation between pages.
+		select {
+		case <-ctx.Done():
+			log.Info().Str("relay", url).Int("total", totalFetched).Msg("Backfill canceled")
+			return totalFetched, ctx.Err()
+		default:
+		}
+
+		filter := nostr.Filter{
+			Kinds:   []int{KindTorrent},
+			Authors: pubkeys,
+			Limit:   pageSize,
+			Until:   until,
+		}
+		if since != nil {
+			filter.Since = since
+		}
+
+		events, err := client.QueryEvents(ctx, []nostr.Filter{filter})
+		if err != nil {
+			log.Error().Err(err).Str("relay", url).Int("page", page).Msg("Backfill page query failed")
+			// Persist what we have so far before bailing out.
+			_ = database.UpdateRelayBackfillProgress(url, oldestSeen, newestSeen, false)
+			return totalFetched, err
+		}
+
+		if len(events) == 0 {
+			// Relay is out of history within (sinceFloor, until]. We're done.
+			completed := sinceFloor == 0
+			if err := database.UpdateRelayBackfillProgress(url, oldestSeen, newestSeen, completed); err != nil {
+				log.Warn().Err(err).Str("relay", url).Msg("Failed to persist backfill checkpoint")
+			}
+			log.Info().
+				Str("relay", url).
+				Int("total", totalFetched).
+				Bool("completed", completed).
+				Msg("Backfill walk finished (empty page)")
+			return totalFetched, nil
+		}
+
+		// Hand events off to the indexer pipeline and update watermarks.
+		var batchOldest, batchNewest int64
+		for i, event := range events {
+			ts := int64(event.CreatedAt)
+			if i == 0 {
+				batchOldest = ts
+				batchNewest = ts
+			} else {
+				if ts < batchOldest {
+					batchOldest = ts
+				}
+				if ts > batchNewest {
+					batchNewest = ts
+				}
+			}
+			handler(event, url)
+		}
+
+		if oldestSeen == 0 || batchOldest < oldestSeen {
+			oldestSeen = batchOldest
+		}
+		if batchNewest > newestSeen {
+			newestSeen = batchNewest
+		}
+
+		totalFetched += len(events)
+		page++
+
+		log.Info().
+			Str("relay", url).
+			Int("page", page).
+			Int("batch", len(events)).
+			Int("total", totalFetched).
+			Int64("batch_oldest", batchOldest).
+			Msg("Backfill page fetched")
+
+		// Persist progress every page so a crash mid-walk is recoverable.
+		if err := database.UpdateRelayBackfillProgress(url, oldestSeen, newestSeen, false); err != nil {
+			log.Warn().Err(err).Str("relay", url).Msg("Failed to persist backfill checkpoint")
+		}
+
+		// Advance Until to the oldest event's timestamp. The deduplicator
+		// handles overlap on same-second events.
+		nextUntil := nostr.Timestamp(batchOldest)
+		if until != nil && nextUntil == *until {
+			// Same timestamp as last page — we've exhausted this second.
+			nextUntil--
+		}
+
+		// Stop if we've crossed the configured floor.
+		if sinceFloor > 0 && int64(nextUntil) < sinceFloor {
+			log.Info().
+				Str("relay", url).
+				Int("total", totalFetched).
+				Int64("since_floor", sinceFloor).
+				Msg("Backfill walk reached time-range floor")
+			// Not "completed" in the absolute sense — there may be older
+			// events past the floor — so leave completed=false.
+			return totalFetched, nil
+		}
+
+		until = &nextUntil
+	}
+}
+
 // FetchContactList fetches contact list from any connected relay
 func (rm *RelayManager) FetchContactList(ctx context.Context, pubkey string) (*nostr.Event, error) {
 	clients := rm.GetConnectedClients()


### PR DESCRIPTION
## What was wrong

The "Resync" button (`POST /api/indexer/resync`) would stop after ~100–1,200 events per relay regardless of the time-range selector. On relays that cap REQ responses at 100 events per subscription (common on U2P relays like `wss://relay.ygg.gratis`, `wss://u2prelais.eliottb.dev`, `wss://u2p.anhkagi.net`), the torrent count would plateau almost immediately even though those relays hold tens of thousands of historical events.

**Root cause:** `Indexer.FetchHistorical(days)` called `RelayManager.SubscribeTrustedTorrents`, which opens a **single unbounded REQ per relay** with `{Kinds:[2003], Authors:[...]}` — no `Until` cursor, no `Limit`, no pagination. On a 100-cap relay you get one batch and EOSE, and that's it. The `days` parameter was accepted by the handler but silently dropped.

Making it worse:

- A paginated fetcher (`FetchAllHistoricalTorrents`) already existed and was used by `Indexer.Start()`, but Resync never called it.
- The only checkpoint was a global `MAX(first_seen_at)` across the whole `torrents` table, so a newly-added relay would be told to resume from "now" even though it had fetched nothing.
- Resync couldn't resume across container restarts — it would start over from scratch every time.

I verified the relay behavior empirically with a standalone Bun script that walks `wss://u2prelais.eliottb.dev` backwards using `until` cursors: each batch returns exactly 100 events, and walking from `now` back to mid-February yielded ~3,800 events before I stopped it. The history is there; Lighthouse just wasn't crawling it.

## What this PR does

Adds a proper bounded-backwards-pagination walker that Resync uses, with per-relay checkpoints persisted in SQLite so restarts resume instead of restart.

### 1. New `relay_backfill_progress` table (`internal/database/schema.sql`)

Tracks per-relay `oldest_fetched_at`, `newest_fetched_at`, and a `completed` flag. Appended to the existing embedded schema (idempotent `CREATE TABLE IF NOT EXISTS`, runs automatically on startup — no migration framework needed).

### 2. New storage helpers (`internal/database/sqlite.go`)

- `GetRelayBackfillProgress(url)` — loads checkpoint, returns zero-value on missing row
- `UpdateRelayBackfillProgress(url, oldest, newest, completed)` — upsert that `MIN`s on `oldest_fetched_at` and `MAX`s on `newest_fetched_at`, so a backwards walk never clobbers a newer watermark written by live ingestion.

### 3. New `BackfillRelay` method (`internal/nostr/relay.go`)

Per-relay paginated walker:

- Resumes from `oldest_fetched_at` checkpoint if present, else starts from `now`
- Pages backwards with `Until` cursor, `Limit: 200` (friendly to low-cap relays)
- Breaks on empty page (= relay out of history)
- Honors a `sinceFloor` unix timestamp derived from the `days` parameter
- Persists checkpoint after **every page** — a mid-walk crash is fully recoverable
- Same-second nudge (`until--`) prevents infinite loops when many events share a timestamp
- Cancellation-aware between pages
- Only marks `completed=true` when a `days=0` walk hits an empty page; a `days>0` walk that hits the floor leaves `completed=false` so a later "no limit" resync will continue

### 4. Rewired `Indexer.FetchHistorical` (`internal/indexer/indexer.go`)

- Computes `sinceFloor` from `days` (0 = no limit, preserving existing API contract)
- Fans out one goroutine per connected relay, semaphore-bounded to 4 concurrent walkers (bounded parallelism without a new dependency — uses `sync.WaitGroup` + buffered channel)
- Each goroutine calls `BackfillRelay`
- **Falls back to the legacy `SubscribeTrustedTorrents`** only if zero relays are connected, so behavior is strictly additive on that edge case
- **Live-tail subscription (started by `Indexer.Start()`) is untouched** — new events keep flowing in parallel with the backfill walk

### 5. Drive-by: `docker-compose.yml` host port override

Changed the hardcoded host port mapping `"9999:9999"` to `"${PORT:-9999}:9999"` so deployers can override the host-side port via a `PORT` environment variable without editing the compose file. The `:-` (colon-dash) form falls back to `9999` when `PORT` is either unset **or** empty, which is the safer default for tools like Dokploy that may pass empty env vars. Internal container port is unchanged, so the healthcheck and `LIGHTHOUSE_SERVER_PORT` behavior are unaffected.

## What this PR does *not* change

- `Indexer.Start()`'s initial historical fetch still uses the existing `FetchAllHistoricalTorrents` path. Unifying that with `BackfillRelay` is a mechanical follow-up but kept out of this PR to minimize diff.
- No changes to the HTTP handler, the live-tail path, the trust/dedup pipeline, or any migrations framework.
- No new Go dependencies.

## Verification

- `go build -tags fts5 ./...` clean
- `go vet -tags fts5 ./...` clean
- `go test -tags fts5 ./internal/database/... ./internal/nostr/... ./internal/indexer/...` passes

## Manual test plan

1. Fresh DB, whitelist the YGG bot, configure `wss://u2prelais.eliottb.dev`, start indexer.
2. Click Resync with **No limit** → torrent count climbs past 3,800 (the floor I verified manually). Logs show `Backfill page fetched` lines with a monotonically decreasing `batch_oldest`.
3. Stop the container mid-walk at ~1,500 events, restart, click Resync again → first log line shows `resumed=true` and `start_until` equals the previous `batch_oldest` (not `now`).
4. Resync with `?days=30` → walks until `nextUntil < now - 30d`, logs "reached time-range floor", DB row has `completed=0`.
5. Resync with `?days=0` to exhaustion → logs "finished (empty page)", DB row has `completed=1`.
6. New live events still flow in while backfill runs (verify by leaving indexer running and watching new torrents appear).

Checkpoints can be inspected with:

```sql
SELECT relay_url,
       datetime(oldest_fetched_at, 'unixepoch') AS oldest,
       datetime(newest_fetched_at, 'unixepoch') AS newest,
       completed
FROM relay_backfill_progress;
```

**Thank you for your work and the well documented project !**